### PR TITLE
Preventing speed change caused by dblclick event

### DIFF
--- a/speedcontrol.js
+++ b/speedcontrol.js
@@ -114,7 +114,6 @@ sophis.VideoControl.prototype.enterDocument = function() {
   var keydownHandler = this.handleKeyDown_.bind(this);
   var keyPressHandler = this.handleKeyPress_.bind(this);
   this.el_.addEventListener('click', clickHandler, true);
-  this.el_.addEventListener('dblclick', clickHandler, true);
   document.body.addEventListener('keydown', keydownHandler, true);
   document.body.addEventListener('keypress', keyPressHandler, true);
   // Set speed indicator to correct amount.
@@ -261,7 +260,6 @@ sophis.VideoControl.prototype.getSpeed = function() {
 sophis.VideoControl.prototype.dispose = function() {
   var clickHandler = this.handleClick_.bind(this);
   this.el_.removeEventListener('click', clickHandler);
-  this.el_.removeEventListener('dblclick', clickHandler);
   this.el_.parentNode.removeChild(this.el_);
 };
 

--- a/speedcontrol.js
+++ b/speedcontrol.js
@@ -284,7 +284,7 @@ sophis.VideoControl.prototype.dispose = function() {
   var clickHandler = this.handleClick_.bind(this);
   var dblClickHandler = this.handleDblClick_.bind(this);
   this.bgEl_.removeEventListener('click', clickHandler);
-  this.bgEl_.removeEventListener('dblclick', clickHandler);
+  this.bgEl_.removeEventListener('dblclick', dblClickHandler);
   this.el_.parentNode.removeChild(this.el_);
 };
 

--- a/speedcontrol.js
+++ b/speedcontrol.js
@@ -111,9 +111,11 @@ sophis.VideoControl.prototype.createDom = function() {
 sophis.VideoControl.prototype.enterDocument = function() {
   var self = this;
   var clickHandler = this.handleClick_.bind(this);
+  var dblClickHandler = this.handleDblClick_.bind(this);
   var keydownHandler = this.handleKeyDown_.bind(this);
   var keyPressHandler = this.handleKeyPress_.bind(this);
   this.el_.addEventListener('click', clickHandler, true);
+  this.el_.addEventListener('dblclick', dblClickHandler, true);
   document.body.addEventListener('keydown', keydownHandler, true);
   document.body.addEventListener('keypress', keyPressHandler, true);
   // Set speed indicator to correct amount.
@@ -214,7 +216,6 @@ sophis.VideoControl.prototype.handleClick_ = function(e) {
   }
   e.preventDefault();
   e.stopPropagation();
-  e.cancelBubble = true;
   if (e.target === this.minusButton_) {
     this.decreaseSpeed();
   } else if (e.target === this.plusButton_) {
@@ -225,6 +226,19 @@ sophis.VideoControl.prototype.handleClick_ = function(e) {
   // Redundant if we listen for 'ratechange', but do it anyway
   this.speedIndicator_.textContent = this.getSpeed();
   return false;
+};
+
+/**
+ * Handles a double-click event on the video controls.
+ * @param {Event} e The native click event.
+ * @private
+ */
+sophis.VideoControl.prototype.handleDblClick_ = function(e) {
+  if (!e.target.classList.contains('sophis-btn')) {
+    return;
+  }
+  e.preventDefault();
+  e.stopPropagation();
 };
 
 /**
@@ -260,6 +274,8 @@ sophis.VideoControl.prototype.getSpeed = function() {
 sophis.VideoControl.prototype.dispose = function() {
   var clickHandler = this.handleClick_.bind(this);
   this.el_.removeEventListener('click', clickHandler);
+  var dblClickHandler = this.handleDblClick_.bind(this);
+  this.el_.removeEventListener('dblclick', dblClickHandler);
   this.el_.parentNode.removeChild(this.el_);
 };
 

--- a/speedcontrol.js
+++ b/speedcontrol.js
@@ -284,8 +284,6 @@ sophis.VideoControl.prototype.dispose = function() {
   var clickHandler = this.handleClick_.bind(this);
   var dblClickHandler = this.handleDblClick_.bind(this);
   this.bgEl_.removeEventListener('click', clickHandler);
-  this.bgEl_.removeEventListener('dblclick', dblClickHandler);
-  this.bgEl_.removeEventListener('click', clickHandler);
   this.bgEl_.removeEventListener('dblclick', clickHandler);
   this.el_.parentNode.removeChild(this.el_);
 };


### PR DESCRIPTION
It is not needed anyway. And clicking fast enough will trigger 2 `click` events followed by a `dblclick`, leading to 3 increments instead of the expected 2.