### PR TITLE
Using shadow DOM and improving CSS.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "HTML5 Video Speed Control",
   "description": "Speed controls for html5 video.",
-  "version": "1.36",
+  "version": "1.37",
   "permissions": [
     "activeTab"
   ],

--- a/speedcontrol.js
+++ b/speedcontrol.js
@@ -40,6 +40,12 @@ sophis.VideoControl = function(targetEl) {
   this.el_ = null;
 
   /**
+   * The shadow container that stores the controls.
+   * @private {Element}
+   */
+  this.bgEl_ = null;
+
+  /**
    * The video element.
    * @private {Element}
    */
@@ -92,6 +98,7 @@ sophis.VideoControl.prototype.createDom = function() {
   this.videoEl_.classList.add('sophis-video');
   this.el_ = container;
   this.el_.classList.add(sophis.VideoControl.CLASS_NAME);
+  this.bgEl_ = bg;
   this.speedIndicator_ = speedIndicator;
   this.minusButton_ = minusButton;
   this.plusButton_ = plusButton;
@@ -115,8 +122,8 @@ sophis.VideoControl.prototype.enterDocument = function() {
   var clickHandler = this.handleClick_.bind(this);
   var keydownHandler = this.handleKeyDown_.bind(this);
   var keyPressHandler = this.handleKeyPress_.bind(this);
-  this.el_.addEventListener('click', clickHandler, true);
-  this.el_.addEventListener('dblclick', clickHandler, true);
+  this.bgEl_.addEventListener('click', clickHandler, true);
+  this.bgEl_.addEventListener('dblclick', clickHandler, true);
   document.body.addEventListener('keydown', keydownHandler, true);
   document.body.addEventListener('keypress', keyPressHandler, true);
   // Set speed indicator to correct amount.
@@ -262,8 +269,8 @@ sophis.VideoControl.prototype.getSpeed = function() {
  */
 sophis.VideoControl.prototype.dispose = function() {
   var clickHandler = this.handleClick_.bind(this);
-  this.el_.removeEventListener('click', clickHandler);
-  this.el_.removeEventListener('dblclick', clickHandler);
+  this.bgEl_.removeEventListener('click', clickHandler);
+  this.bgEl_.removeEventListener('dblclick', clickHandler);
   this.el_.parentNode.removeChild(this.el_);
 };
 

--- a/speedcontrol.js
+++ b/speedcontrol.js
@@ -68,16 +68,19 @@ sophis.VideoControl.CLASS_NAME = 'sophis-video-control';
  * Creates the HTML body of the controls.
  */
 sophis.VideoControl.prototype.createDom = function() {
-  var fragment = document.createDocumentFragment();
   var container = document.createElement('div');
+  var shadow = container.createShadowRoot();
+  var bg = document.createElement('div');
   var speedIndicator = document.createElement('span');
   var minusButton = document.createElement('button');
   var plusButton = document.createElement('button');
   var closeButton = document.createElement('a');
-  container.appendChild(minusButton);
-  container.appendChild(speedIndicator);
-  container.appendChild(plusButton);
-  container.appendChild(closeButton);
+  shadow.appendChild(bg);
+  bg.appendChild(minusButton);
+  bg.appendChild(speedIndicator);
+  bg.appendChild(plusButton);
+  bg.appendChild(closeButton);
+  bg.classList.add('sophis-bg');
   speedIndicator.classList.add('speed-indicator');
   minusButton.textContent = '-';
   minusButton.classList.add('sophis-btn', 'decrease');
@@ -85,8 +88,7 @@ sophis.VideoControl.prototype.createDom = function() {
   plusButton.classList.add('sophis-btn', 'increase');
   closeButton.classList.add('sophis-btn', 'sophis-close-button');
   closeButton.textContent = 'close';
-  fragment.appendChild(container);
-  this.videoEl_.parentElement.insertBefore(fragment, this.videoEl_);
+  this.videoEl_.parentElement.insertBefore(container, this.videoEl_);
   this.videoEl_.classList.add('sophis-video');
   this.el_ = container;
   this.el_.classList.add(sophis.VideoControl.CLASS_NAME);
@@ -278,6 +280,7 @@ sophis.VideoControl.insertAll = function () {
     }
   });
 };
+
 // Listen for new video elements and inject into it.
 document.addEventListener('DOMNodeInserted', function(event) {
   var node = event.target || null;

--- a/style.css
+++ b/style.css
@@ -1,30 +1,28 @@
-.sophis-video {
-  position: relative;
-  text-align: center;
-  font-family: "Helvetica Neue Light", Helvetica, Arial, sans-serif;
-}
-
 .sophis-video-control {
   position: absolute;
+  z-index: 9999999;
+}
+
+.sophis-video-control::shadow .sophis-bg {
+  transition: opacity 0.25s;
+  opacity: 0.3;
+  -webkit-user-select: none;
+  font: 12px/1em "Helvetica Neue Light", Helvetica, Arial, sans-serif;
+  vertical-align: middle;
   background: black;
   color: white;
   border-radius: 5px;
   border: 1px solid #ccc;
   padding: 5px;
-  z-index: 9999999;
-  outline: none;
-  opacity: 0.3;
-  -webkit-transition: all 0.5s;
   margin: 10px;
-  -webkit-user-select: none;
-  cursor: pointer;
+  position: relative;
 }
 
-.sophis-video-control:hover {
+.sophis-video-control:hover::shadow .sophis-bg {
   opacity: 1;
 }
 
-.sophis-video-control .sophis-btn {
+.sophis-video-control::shadow .sophis-btn {
   display: inline-block;
   height: 20px;
   width: 20px;
@@ -37,24 +35,28 @@
   line-height: 20px;
   padding: 0;
   vertical-align: center;
+  cursor: pointer;
 }
 
-.sophis-video-control .sophis-btn:active {
+.sophis-video-control::shadow .sophis-btn:active {
   border: 1px solid lightblue;
   color: lightblue;
 }
 
-.sophis-video-control .speed-indicator {
+.sophis-video-control::shadow .speed-indicator {
   color: white;
   padding: 0 10px;
+  cursor: default;
 }
 
-.sophis-btn.sophis-close-button {
+.sophis-video-control::shadow .sophis-btn.sophis-close-button {
   position: absolute;
   border-radius: none;
   background: none;
   bottom: -20px;
-  left: -webkit-calc(50% - 10px);
+  left: calc(50% - 15px);
+  width: 30px;
+  text-align: center;
   margin: auto;
   display: block;
   color: #ccc;


### PR DESCRIPTION
In summary: CSS improvements and Shadow DOM. Read the commit messages for more info. :)

Tested here:

* http://www.theguardian.com/artanddesign/2014/may/12/marina-abramovic-ready-to-die-serpentine-gallery-512-hours — The video does not load for me (probably region-restriction or something), but the layout is not broken anymore.
* http://photography.tutsplus.com/courses/the-photographers-portfolio — The speed can't be changed by the extension, there is a code JavaScript in that site that constantly (every 1 second?) resets the speed to one of the known values.
* http://www.html5rocks.com/en/tutorials/video/basics/ — Works fine. Now the layout of the extension controls is preserved.

Note: Needs some trivial merging with my pull request #10.

Unrelated note: Maybe you want to delete some [old branches from your repo](https://github.com/benedictchen/google-chrome-html5video-controls/branches).