### PR TITLE
Removed left and right arrow key speed controls

### DIFF
--- a/speedcontrol.js
+++ b/speedcontrol.js
@@ -200,11 +200,9 @@ sophis.VideoControl.prototype.handleKeyDown_ = function(e) {
   if (keyCode) {
     switch (keyCode) {
       case KeyCodes.DOWN:
-      case KeyCodes.LEFT:
         this.decreaseSpeed();
       break;
       case KeyCodes.UP:
-      case KeyCodes.RIGHT:
         this.increaseSpeed();
       break;
       default:


### PR DESCRIPTION
It was *really* annoying for video players that allow you to rewind/fastforward with the left/right arrow keys

This fixes that